### PR TITLE
Handle spaces in hwid

### DIFF
--- a/rich-core-extract/rich-core-extract.c
+++ b/rich-core-extract/rich-core-extract.c
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    snprintf(buf, 255, "lzop -d -c %s", input_fn);
+    snprintf(buf, 255, "lzop -d -c \"%s\"", input_fn);
     input_file = popen(buf, "r");
     output_file = fopen("/dev/null", "w");
     if (!input_file)

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -485,8 +485,8 @@ else
       if [ x"$REDUCE_CORE" = x"true" ] && [ -n ${core_exe} ]; then
 		originalcorefilename=${rcorefilename}.core.in
 		cat > ${originalcorefilename}
-		core-reducer -i ${originalcorefilename} -o /dev/stdout -e ${core_exe}
-		rm ${originalcorefilename}	
+		core-reducer -i "${originalcorefilename}" -o /dev/stdout -e ${core_exe}
+		rm "${originalcorefilename}"
       else
         cat
       fi
@@ -495,7 +495,7 @@ fi
 _section_rich_core_errors
 ) | lzop > ${rcorefilename}.tmp
 
-mv ${rcorefilename}.tmp ${rcorefilename}.rcore.lzo
+mv "${rcorefilename}.tmp" "${rcorefilename}.rcore.lzo"
 
 # count cores per application
 if [ ! -d /var/lib/dsme/rich-cores ]; then


### PR DESCRIPTION
In Sailfish SDK emulator image, 'ssu model -s' prints:

SDK Emulator Wayland

This patch handles spaces in resulting core image filename.
