### PR TITLE
Revert "check executable name from /proc/pid/cmdline"

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -473,7 +473,7 @@ if [ x"$NO_SECTION_HEADER" = x"true" ] && [ -z ${core_pid} ]; then
 fi
 
 # figure out the executable
-core_exe=`cat /proc/${core_pid}/cmdline | cut -d '' -f 1`
+core_exe=`readlink -f /proc/${core_pid}/exe`
 core_exe_basename=${core_exe##*/}
 
 # if process is invoker, don't create a core


### PR DESCRIPTION
This reverts commit 2a281de8bef62d5dc0230023c7b01dbc6cb0384e.

We believe the real problem cause was fixed in bbcfd6ae and this
change causes more trouble than it solves.
