### PR TITLE
Don't remove core_pattern on system shutdown

### DIFF
--- a/scripts/rich-core-pattern.service
+++ b/scripts/rich-core-pattern.service
@@ -9,7 +9,6 @@ RemainAfterExit=yes
 ExecStartPre=/usr/bin/test -x /usr/sbin/rich-core-dumper
 ExecStartPre=/usr/bin/test -d /var/cache/core-dumps
 ExecStart=/bin/sh -c "/sbin/sysctl -w kernel.core_pattern=\'|/usr/sbin/rich-core-dumper --pid=%%p --signal=%%s --name=%%e\'"
-ExecStop=/bin/sh -c "/sbin/sysctl -w kernel.core_pattern=/var/cache/core-dumps/%%e-%%s-%%p.core"
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Some executables can still crash after core_pattern is removed. Those
cores were dumped into /var/cache/core-dumps, ignored by crash-reporter,
not being deleted and slowly consuming available space. In order to
prevent it, we keep the pattern set until the full system halt.
