### PR TITLE
Fix possible infinite loop in ProcInterface::heapAddress

### DIFF
--- a/core-reducer/procinterface.cpp
+++ b/core-reducer/procinterface.cpp
@@ -71,6 +71,11 @@ ADDRESS ProcInterface::heapAddress(const char *fileName) const
                     break;
                 }
             }
+            else if (ferror(fd))
+            {
+                LOG(LOG_ERR, "Error reading from %s", useFileName);
+                break;
+            }
         }
         fclose(fd);
     }


### PR DESCRIPTION
We have to check for error after fgets().
