### PR TITLE
[core-reducer] Try to find the stack even if sp overflowed

### DIFF
--- a/core-reducer/reducer.cpp
+++ b/core-reducer/reducer.cpp
@@ -36,6 +36,8 @@
 
 //add some additional space on the stack
 #define STACK_ADDITION 128
+//tolerance for sp being past the edge of the stack segment
+#define STACK_OVERFLOW_GUESS 8192
 // predefined heap address, will be used if an application does not have heap
 #define PREDEFINED_HEAP_ADDRESS 4
 
@@ -273,6 +275,8 @@ void Reducer::getStacks()
     for (unsigned int i = 0; i < stackPointerAddresses.size(); i++)
     {
         const Phdr *coreSegment = coreReader->getSegmentByAddress(stackPointerAddresses.at(i));
+        if (!coreSegment)
+            coreSegment = coreReader->getSegmentByAddress(stackPointerAddresses.at(i) + STACK_OVERFLOW_GUESS);
         if (!coreSegment)
             continue;
 


### PR DESCRIPTION
This patch gives us a chance to get the stack if a program crashed due to infinite recursion.
