### PR TITLE
Distinguish spontaneous HW reboot reports by name

### DIFF
--- a/scripts/rich-core-pattern.service
+++ b/scripts/rich-core-pattern.service
@@ -8,8 +8,15 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/usr/bin/test -x /usr/sbin/rich-core-dumper
 ExecStartPre=/usr/bin/test -d /var/cache/core-dumps
-ExecStartPre=-/bin/sh -c '/usr/bin/test ! -f /tmp/richcore-hwreset-mark && /bin/grep -q pwr_on_status=pwr_on_by_HW_ /proc/cmdline && /usr/sbin/rich-core-dumper --name=HwReboot --signal=$RANDOM'
+
+# Test whether last reboot was caused by a hardware event and if so, gather the
+# log files into a crash report.
+ExecStartPre=-/bin/sh -c '/usr/bin/test ! -f /tmp/richcore-hwreset-mark && \
+	STATUS=$(/bin/sed -n "s|.*pwr_on_status=pwr_on_by_HW_\([^ ]*\).*|HW\1|p" /proc/cmdline) && \
+	/usr/bin/test -n "$STATUS" && \
+	/usr/sbin/rich-core-dumper --name=$STATUS --signal=$RANDOM'
 ExecStartPre=-/bin/touch /tmp/richcore-hwreset-mark
+
 ExecStart=/bin/sh -c "/sbin/sysctl -w kernel.core_pattern=\'|/usr/sbin/rich-core-dumper --pid=%%p --signal=%%s --name=%%e\'"
 
 [Install]


### PR DESCRIPTION
Crash report is now named according to pwr_on_status in the kernel boot
parameters. Status pwr_on_by_HW_something creates a crash report with
name 'HWsomething'.
