### PR TITLE
Set kernel.core_pattern in sysctl/sp-rich-core.conf

### DIFF
--- a/scripts/rich-core-pattern.service
+++ b/scripts/rich-core-pattern.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Rich core pattern
+Description=Collection of HWreset rich cores
 Requires=local-fs.target
 After=local-fs.target
 
@@ -15,9 +15,7 @@ ExecStartPre=-/bin/sh -c '/usr/bin/test ! -f /tmp/richcore-hwreset-mark && \
 	STATUS=$(/bin/sed -n "s|.*pwr_on_status=pwr_on_by_HW_\([^ ]*\).*|HW\1|p" /proc/cmdline) && \
 	/usr/bin/test -n "$STATUS" && \
 	/usr/sbin/rich-core-dumper --name=$STATUS --signal=$RANDOM'
-ExecStartPre=-/bin/touch /tmp/richcore-hwreset-mark
-
-ExecStart=/bin/sh -c "/sbin/sysctl -w kernel.core_pattern=\'|/usr/sbin/rich-core-dumper --pid=%%p --signal=%%s --name=%%e\'"
+ExecStart=/bin/touch /tmp/richcore-hwreset-mark
 
 [Install]
 WantedBy=basic.target

--- a/sysctl/sp-rich-core.conf
+++ b/sysctl/sp-rich-core.conf
@@ -4,3 +4,6 @@
 
 # Set the core dump mode for setuid or otherwise protected/tainted binaries
 fs.suid_dumpable = 2
+
+# Set the core pattern so that cores are piped into our rich-core-dumper script.
+kernel.core_pattern=|/usr/sbin/rich-core-dumper --pid=%p --signal=%s --name=%e

--- a/tests/test_extract
+++ b/tests/test_extract
@@ -1,18 +1,16 @@
 #!/bin/sh
 
+RICH_CORE_SYSCTL_CONF=/usr/lib/sysctl.d/sp-rich-core.conf
+
 _disable_rich_core_dumper()
 {
-  # disable rich core dumper
-  if [ -e /lib/systemd/system/rich-core-pattern.service ]; then
-    systemctl stop rich-core-pattern.service
-  fi
+  /sbin/sysctl -w kernel.core_pattern=core
 }
 
 _enable_rich_core_dumper()
 {
-  # enable
-  if [ -e /lib/systemd/system/rich-core-pattern.service ]; then
-    systemctl start rich-core-pattern.service
+  if [ -e $RICH_CORE_SYSCTL_CONF ]; then
+    /sbin/sysctl -p $RICH_CORE_SYSCTL_CONF
   fi
 }
 

--- a/tests/test_script
+++ b/tests/test_script
@@ -32,6 +32,7 @@ _obtain_configuration()
   # default values
 
   SCRIPT_ADDITIONAL_KEY="core-reducer-testing"
+  RICH_CORE_SYSCTL_CONF=/usr/lib/sysctl.d/sp-rich-core.conf
 }
 
 _parse_arguments()
@@ -57,17 +58,13 @@ _wait()
 
 _disable_rich_core_dumper()
 {
-  # disable rich core dumper
-  if [ -e /lib/systemd/system/rich-core-pattern.service ]; then
-    systemctl stop rich-core-pattern.service
-  fi
+  /sbin/sysctl -w kernel.core_pattern=core
 }
 
 _enable_rich_core_dumper()
 {
-  # enable
-  if [ -e /lib/systemd/system/rich-core-pattern.service ]; then
-    systemctl start rich-core-pattern.service
+  if [ -e $RICH_CORE_SYSCTL_CONF ]; then
+    /sbin/sysctl -p $RICH_CORE_SYSCTL_CONF
   fi
 }
 


### PR DESCRIPTION
systemd set the pattern too late and thus some crashes early after boot
weren't caught.

Renamed rich-core-collect-hwreset.service to rich-core-pattern.service.
The service now solely triggers creation of reports after HW reboots.
