### PR TITLE
Limit journalctl dump to current boot

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -269,7 +269,7 @@ _dump_logs()
   _print_file_with_header /var/log/Xorg.0.log
   _print_file_with_header /var/log/Xorg.0.log.old
 
-  _print_command_with_header /bin/journalctl
+  _print_command_with_header /bin/journalctl -b
   _print_command_with_header /bin/dmesg
   _print_command_with_header /system/bin/logcat -d -b main -b radio
 


### PR DESCRIPTION
Prevents huge uploads when persistent storage of journal is enabled.
