### PR TITLE
Don't su to 'nemo' when checking network_type

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -543,7 +543,7 @@ if ! _check_core_location; then
   exit
 fi
 
-network_type=$(su nemo -c 'cat /run/state/namespaces/Internet/NetworkType')
+network_type=$(cat /run/state/namespaces/Internet/NetworkType)
 has_suitable_network_connection=false
 
 # Don't download anything when on a network that charges for data.


### PR DESCRIPTION
This is a leftover from when NetworkType used to be at
/run/user/100000/state/namespaces/Internet/NetworkType and could be read
only by nemo user. We don't need to su anymore now when it resides in
/run/state.

Fixes a potential hangup on journald crash, since su wants to write into
the journal.
