### PR TITLE
Ensure *.core.in files are removed if user didn't intend to keep them

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -732,7 +732,7 @@ elif [ "${omit_core}" != "true" ] && [ "${core_pid}" -gt 0 ]; then
   # By default core is read from stdin.
   originalcorefilename=-
   if [ x"$REDUCE_CORE" = x"true" ] || [ x"$INCLUDE_STACK_TRACE" = x"true" ]; then
-    originalcorefilename=${rcorebasename}.core.in
+    originalcorefilename=${rcorebasename}.core.in.tmp
     cat > ${originalcorefilename}
   fi
 
@@ -749,8 +749,12 @@ elif [ "${omit_core}" != "true" ] && [ "${core_pid}" -gt 0 ]; then
     _capture_stacktrace
   fi
 
-  if [ x"$KEEP_UNSTRIPPED_CORE" != x"true" ] && [ -f "${originalcorefilename}" ]; then
-    rm "${originalcorefilename}"
+  if [ -f "${originalcorefilename}" ]; then
+    if [ x"$KEEP_UNSTRIPPED_CORE" = x"true" ]; then
+      mv "${originalcorefilename}" "${originalcorefilename%.tmp}"
+    else
+      rm "${originalcorefilename}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Unexpected abortion of rich-core-dumper can leave temporary *.core.in
files behind, which then take up device memory until manually removed.

In order to conserver space, *.core.in is named *.core.in.tmp during
the script execution and is eventually either deleted or, when
KEEP_UNSTRIPPED_CORE=true, renamed to *.core.in.

If the core dumper exits abnormally, the leftover *.tmp file is removed
after two days by already implemented cleanup mechanism.
