### PR TITLE
Don't start rich-core-early-collect.service in %post

### DIFF
--- a/sp-rich-core.spec
+++ b/sp-rich-core.spec
@@ -95,5 +95,3 @@ make distclean
 
 %post
 /sbin/sysctl -p /usr/lib/sysctl.d/sp-rich-core.conf
-systemctl daemon-reload
-systemctl start rich-core-early-collect.service


### PR DESCRIPTION
Would require a dependency on systemd; it's enough to run early
collection after reboot, not immediately after sp-rich-core is installed
on device.
