### PR TITLE
Use pkcon instead of rpm for package queries

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -247,10 +247,16 @@ _section_user_message()
   fi
 }
 
+_pkcon_query_installed()
+{
+  _run_with_timeout 30 pkcon --plain --noninteractive --filter=installed $@ \
+    | awk '/^Installed / {print $2}'
+}
+
 _section_packagelist()
 {
   _print_header packagelist
-  _run_with_timeout 5 rpm -qa
+  _pkcon_query_installed get-packages
 }
 
 _section_repositories()
@@ -335,7 +341,7 @@ _section_ssu_status()
 _section_exe_package()
 {
   _print_header exe-package
-  _run_with_timeout 5 rpmquery -f ${core_exe}
+  _pkcon_query_installed search file ${core_exe}
 }
 
 _get_vmsizes()


### PR DESCRIPTION
Killing rpm after timeout can cause package database corruption and/or keep the db locked. If pkcon timeouts for whatever reason, only the client is killed, leaving packagekitd, which is actually accessing the database, running.
