### PR TITLE
Handle missing settings in configuration files.

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -43,11 +43,17 @@ _read_config_variable()
 {
   value=$2 
   if [ -e $system_settings/crash-reporter-privacy.conf ]; then
-    value=$(awk -F "=" "/$1/ {print \$2}" $system_settings/crash-reporter-privacy.conf)
+    v=$(awk -F "=" "/$1/ {print \$2}" $system_settings/crash-reporter-privacy.conf)
+    if [ "$v" != "" ]; then
+      value=$v
+    fi
   fi
 
   if [ -e $user_settings/crash-reporter-privacy.conf ]; then
-    value=$(awk -F "=" "/$1/ {print \$2}" $user_settings/crash-reporter-privacy.conf)
+    v=$(awk -F "=" "/$1/ {print \$2}" $user_settings/crash-reporter-privacy.conf)
+    if [ "$v" != "" ]; then
+      value=$v
+    fi
   fi
 
   echo $value


### PR DESCRIPTION
This is unlikely if the settings are only changed via the UI. If the
setting key is not found don't override the default or system value.