### PR TITLE
Remove statefs use

### DIFF
--- a/rpm/sp-rich-core.spec
+++ b/rpm/sp-rich-core.spec
@@ -21,6 +21,9 @@ Requires: ssu-sysinfo
 Requires: findutils
 # awk used by scripts/rich-core-dumper
 Requires: gawk
+# dbus, connman used by scripts/rich-core-dumper
+Requires: dbus
+Requires: connman
 # getent used by scripts/rich-core-dumper
 Requires: glibc-common
 

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -214,7 +214,7 @@ _section_ifconfig()
 
 _section_df()
 {
-  _print_command_with_header /bin/df -x fuse.statefs
+  _print_command_with_header /bin/df
 }
 
 _section_ls_proc()
@@ -600,16 +600,24 @@ if ! _check_core_location; then
   exit
 fi
 
-if [ "$core_name" != "statefs" ]; then
-  network_type=$(cat /run/state/namespaces/Internet/NetworkType)
-fi
+network_type=$(dbus-send --system --type=method_call --print-reply --dest=net.connman / net.connman.Manager.GetTechnologies | awk '
+BEGIN { connected = ""; }
+/object path/ { t = 0; c = 0; type=""; next; }
+/string "Type"$/ { t = 1; next; }
+/string "Connected"$/ { c = 1; next; }
+t == 1 && /string/ { type = gensub(/^.*string "(.*)".*$/,"\\1", "g"); t = 0; next; }
+c == 1 && /boolean/ { c = gensub(/^.*boolean (.*)$/,"\\1", "g") == "true" ? 2 : 0; next; }
+c == 2 && type != "" { connected = type; type = ""; c = 0; }
+END { print(connected) }
+')
 
 has_suitable_network_connection=false
 
 # Don't download anything when on a network that charges for data.
-# Valid NetworkType values are from src/connman/provider_connman.cpp in
-# Nemo Mobile's statefs-providers.
-if [ x"$network_type" = x"WLAN" -o x"$network_type" = x"ethernet" ]; then
+# Valid NetworkType values are from connman/plugins/*.c files defined as .name
+# values in the connman_technology_driver structs. The following will list them.
+# grep "struct connman_technology_driver" connman/plugins/* -A1 | grep -o "\".*\""
+if [ x"$network_type" = x"wifi" -o x"$network_type" = x"ethernet" ]; then
   has_suitable_network_connection=true
 fi
 


### PR DESCRIPTION
Makes two changes:

1. Removes the statefs exception from the `df` call. Busybox `df` doesn't output statefs info and doesn't support the `-x` option anyway.
2. Collects the current network connection from connman via dbus rather than via statefs.

This still needs proper testing, as I've only checked the parts in isolation. I think this already gives a good idea about the approach though.